### PR TITLE
Use 0 for root word id

### DIFF
--- a/tuw_nlp/graph/ud_graph.py
+++ b/tuw_nlp/graph/ud_graph.py
@@ -181,24 +181,26 @@ class UDGraph(Graph):
                 # token representing an mwe, e.g. "vom" ~ "von dem"
                 continue
             name = word.get("lemma", word["text"])
+            node_id = i+1
             G.add_node(
-                i,
+                node_id,
                 name=name,
                 token_id=word["id"],
                 upos=word["upos"],
                 asciiname=anyascii(name),
             )
-            self.tok_ids_to_nodes[word["id"]] = i
+            self.tok_ids_to_nodes[word["id"]] = node_id
             if word["deprel"] == "root":
-                G.add_node(-1, name="root", upos="ROOT")
-                self.tok_ids_to_nodes[0] = -1
+                G.add_node(0, name="root", upos="ROOT")
+                self.tok_ids_to_nodes[0] = 0
 
         for i, word in enumerate(sen.to_dict()):
             if not isinstance(word["id"], int):
                 # multi-word token
                 continue
             head_node = self.tok_ids_to_nodes[word["head"]]
-            G.add_edge(head_node, i)
-            G[head_node][i].update({"color": preprocess_edge_alto(word["deprel"])})
+            node_id = i + 1
+            G.add_edge(head_node, node_id)
+            G[head_node][node_id].update({"color": preprocess_edge_alto(word["deprel"])})
 
         return G


### PR DESCRIPTION
-1 as root id creates confusion in the to_dot method, where "-" characters are replaced by "_".